### PR TITLE
Add error message from trackhive if present

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -3,16 +3,19 @@ const api = express.Router();
 const {logger, get, post, del} = require('../lib');
 
 const AUTH = { Authorization: 'Bearer ' + process.env.TOKEN };
+const msgMap = {
+	401: 'Auth token is invalid.',
+	409: 'Parcel is already added.',
+	429: 'Too many requests. Please wait 10 seconds and try again.',
+	500: 'Internal server error.'
+};
 
 function catchError (e, res) {
 	const code = e && e.response && e.response.status || 500;
-	const msgMap = {
-		401: 'Auth token is invalid.',
-		409: 'Parcel is already added.',
-		429: 'Too many requests. Please wait 10 seconds and try again.',
-		500: 'Internal server error.'
-	};
-	const msg = msgMap[code] || e.response.statusText;
+	let msg = msgMap[code] || e.response.statusText;
+	if (e.response.data && e.response.data.meta && e.response.data.meta.message && e.response.data.meta.message.length > 0) {
+		msg += `: ${ e.response.data.meta.message.join('. ') }`;
+	}
 	logger.error(msg);
 	res.status(code).json({ code, msg });
 }


### PR DESCRIPTION
Currently if TrackHive's API return an HTTP status that's not 200, the back-end only returns the status' name.

TrackHive gives us messages explaining the error but unfortunately they aren't forwarded to the user, who is left to guess why their request failed.

With this modification, the back-end now appends the error message(s) to the status name. I also took the opportunity to move `msgMap` outside of `catchError` as to not re-create the map every time the function is called.